### PR TITLE
Set model to optional and use locales error messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::API
+  def render_error(status, messages)
+    render json: {
+      error: messages,
+    }, status: status
+  end
+
+  def render_success_no_data(message)
+    render json: {
+      message: message,
+    }, status: :ok
+  end
 end

--- a/app/controllers/user_follows_controller.rb
+++ b/app/controllers/user_follows_controller.rb
@@ -4,18 +4,18 @@ class UserFollowsController < ApplicationController
     followee_id = params[:followee_id]
 
     unless User.exists?(actor)
-      render json: { error: "Follower/actor does not exist" }, status: :not_found and return
+      render_error(:not_found, I18n.t('errors.messages.record_not_found', record: 'Actor')) and return
     end
 
     unless User.exists?(followee_id)
-      render json: { error: "Followee does not exist" }, status: :not_found and return
+      render_error(:not_found, I18n.t('errors.messages.record_not_found', record: 'Followee')) and return
     end
 
     follow = UserFollow.new(follower_id: actor, followee_id: followee_id)
     if follow.save
-      render json: { message: "Successfully followed user #{followee_id}" }, status: :ok
+      render_success_no_data(I18n.t('success.messages.follow_success', followee_id: followee_id))
     else
-      render json: { error: follow.errors.full_messages }, status: :internal_server_error
+      render_error(:internal_server_error, follow.errors.full_messages)
     end
   end
 

--- a/app/models/user_follow.rb
+++ b/app/models/user_follow.rb
@@ -1,8 +1,8 @@
 class UserFollow < ApplicationRecord
-  belongs_to :follower, class_name: 'User'
-  belongs_to :followee, class_name: 'User'
+  belongs_to :follower, class_name: 'User', optional: true
+  belongs_to :followee, class_name: 'User', optional: true
 
-  validates :follower_id, uniqueness: { scope: :followee_id, message: "This user has been followed" }
+  validates :follower_id, uniqueness: { scope: :followee_id, message: I18n.t('activerecord.errors.has_been_followed') }
 
   validate :following_self
 
@@ -10,7 +10,7 @@ class UserFollow < ApplicationRecord
 
   def following_self
     if follower_id == followee_id
-      errors.add(:follower, :blank, message: "cannot be the same as Followee")
+      errors.add(:follower, :blank, message: I18n.t('activerecord.errors.following_self'))
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,31 +1,11 @@
-# Files in the config/locales directory are used for internationalization and
-# are automatically loaded by Rails. If you want to use locales other than
-# English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more about the API, please read the Rails Internationalization guide
-# at https://guides.rubyonrails.org/i18n.html.
-#
-# Be aware that YAML interprets the following case-insensitive strings as
-# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
-# must be quoted to be interpreted as strings. For example:
-#
-#     en:
-#       "yes": yup
-#       enabled: "ON"
-
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      following_self: "cannot be the same as Followee"
+      has_been_followed: "This user has been followed"
+  success:
+    messages:
+      follow_success: "Succesfully followed user %{followee_id}"
+  errors:
+    messages:
+      record_not_found: "%{record} does not exist"

--- a/spec/controllers/user_follows_controller_spec.rb
+++ b/spec/controllers/user_follows_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UserFollowsController, type: :controller do
       it "returns not found error" do
         post :create, params: { actor: 100, followee_id: 100 }
         expect(response).to have_http_status(:not_found)
-        expect(JSON.parse(response.body)["error"]).to eq("Follower/actor does not exist")
+        expect(JSON.parse(response.body)["error"]).to include("Actor does not exist")
       end
     end
 


### PR DESCRIPTION
1. Modify the belongs_to into optional. Because activerecord will automatically validate associations exist in the table, if it doesn't exist, it will raise error. By making this optional, we validate manually from controller so we have greater clarity especially for those who are new to ruby. But if we don't care about clarity, we can remove the optional and let activerecord do the magic.
2. set all messages to locales instead for cleaner code and seperate render function